### PR TITLE
feat: add CloudWatch Alarm SNS topic and email subject #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The module can send CloudWatch Logs alerts to email subscribers through Amazon S
 ```hcl
 module "cloudwatch_logs_notifier" {
   source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-  
+
   email_subscribers = ["alerts@example.com", "team@example.com"]
   email_subject     = "AWS CloudWatch Alert"  # Customize the email subject
   log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
@@ -43,12 +43,12 @@ The module can also send CloudWatch Logs alerts to Slack channels through webhoo
 ```hcl
 module "cloudwatch_logs_notifier" {
   source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-  
+
   enable_slack_notifications = true
   slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
   slack_channel = "#alerts"
   slack_username = "CloudWatch Logs Bot"
-  
+
   log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
 }
 ```
@@ -60,16 +60,16 @@ The module can create a dedicated SNS topic for CloudWatch Alarms to trigger the
 ```hcl
 module "cloudwatch_logs_notifier" {
   source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-  
+
   # Enable CloudWatch Alarm SNS Topic
   create_cloudwatch_alarm_sns_topic = true
   cloudwatch_alarm_sns_topic_name   = "my-alarm-topic"
-  
+
   # Configure notification channels
   enable_slack_notifications = true
   slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
   slack_channel = "#alerts"
-  
+
   email_subscribers = ["alerts@example.com"]
 }
 
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "example" {
   alarm_description   = "This metric monitors Lambda function CPU utilization"
   alarm_actions       = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
   ok_actions          = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
-  
+
   dimensions = {
     FunctionName = "my-lambda-function"
   }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,98 @@
+# CloudWatch Logs Notification Module for AWS
+
+[![codecov](https://codecov.io/gh/DevHatRo/terraform-aws-module-cloudwatchlog-notify/graph/badge.svg?token=UPRDDCJZ1P)](https://codecov.io/gh/DevHatRo/terraform-aws-module-cloudwatchlog-notify)
+
+This Terraform module deploys a complete solution for receiving CloudWatch Logs events and sending notifications through SNS.
+
+## Architecture
+
+This module sets up:
+
+1. A Lambda function that processes CloudWatch Logs events
+2. An SNS topic that receives notifications from the Lambda function
+3. CloudWatch Logs subscription filters for the specified log groups
+4. All necessary IAM permissions and policies
+
+The Lambda function supports:
+- Processing CloudWatch Logs events directly
+- Processing events via SNS
+- Parsing JSON log messages, including Kubernetes logs
+- Custom formatting for different log types
+- Processing CloudWatch Alarm notifications
+
+## Features
+
+### Email Notifications
+
+The module can send CloudWatch Logs alerts to email subscribers through Amazon SNS.
+
+```hcl
+module "cloudwatch_logs_notifier" {
+  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
+  
+  email_subscribers = ["alerts@example.com", "team@example.com"]
+  email_subject     = "AWS CloudWatch Alert"  # Customize the email subject
+  log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
+}
+```
+
+### Slack Notifications
+
+The module can also send CloudWatch Logs alerts to Slack channels through webhooks.
+
+```hcl
+module "cloudwatch_logs_notifier" {
+  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
+  
+  enable_slack_notifications = true
+  slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  slack_channel = "#alerts"
+  slack_username = "CloudWatch Logs Bot"
+  
+  log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
+}
+```
+
+### CloudWatch Alarm SNS Topic
+
+The module can create a dedicated SNS topic for CloudWatch Alarms to trigger the Lambda function. This allows you to have your CloudWatch Alarms send notifications through the same pipeline as your CloudWatch Logs.
+
+```hcl
+module "cloudwatch_logs_notifier" {
+  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
+  
+  # Enable CloudWatch Alarm SNS Topic
+  create_cloudwatch_alarm_sns_topic = true
+  cloudwatch_alarm_sns_topic_name   = "my-alarm-topic"
+  
+  # Configure notification channels
+  enable_slack_notifications = true
+  slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  slack_channel = "#alerts"
+  
+  email_subscribers = ["alerts@example.com"]
+}
+
+# Example CloudWatch Alarm that sends to the CloudWatch Alarm SNS topic
+resource "aws_cloudwatch_metric_alarm" "example" {
+  alarm_name          = "example-high-cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "This metric monitors Lambda function CPU utilization"
+  alarm_actions       = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
+  ok_actions          = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
+  
+  dimensions = {
+    FunctionName = "my-lambda-function"
+  }
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -32,16 +127,22 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_policy_statements"></a> [additional\_policy\_statements](#input\_additional\_policy\_statements) | Additional IAM policy statements to attach to the Lambda function | `any` | `{}` | no |
+| <a name="input_cloudwatch_alarm_sns_topic_name"></a> [cloudwatch\_alarm\_sns\_topic\_name](#input\_cloudwatch\_alarm\_sns\_topic\_name) | The name of the SNS topic for CloudWatch alarm notifications | `string` | `"cloudwatch-alarm-notifications"` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data for Lambda | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | The number of days to retain Lambda logs | `number` | `14` | no |
+| <a name="input_create_cloudwatch_alarm_sns_topic"></a> [create\_cloudwatch\_alarm\_sns\_topic](#input\_create\_cloudwatch\_alarm\_sns\_topic) | Whether to create an SNS topic for CloudWatch alarms | `bool` | `false` | no |
 | <a name="input_create_cloudwatch_log_subscription_filter"></a> [create\_cloudwatch\_log\_subscription\_filter](#input\_create\_cloudwatch\_log\_subscription\_filter) | Whether to create the CloudWatch log subscription filter | `bool` | `true` | no |
 | <a name="input_create_lambda_function"></a> [create\_lambda\_function](#input\_create\_lambda\_function) | Whether to create the Lambda function | `bool` | `true` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create the SNS topic | `bool` | `true` | no |
 | <a name="input_email_subscribers"></a> [email\_subscribers](#input\_email\_subscribers) | List of email addresses to subscribe to the SNS topic | `list(string)` | `[]` | no |
+| <a name="input_enable_slack_notifications"></a> [enable\_slack\_notifications](#input\_enable\_slack\_notifications) | Whether to enable Slack notifications | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to enable all resources | `bool` | `true` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | The filter pattern to use for CloudWatch log subscriptions | `string` | `"{$.kubernetes.namespace_name = \"*\" && $.kubernetes.pod_name = \"*\" && $.kubernetes.container_name = \"*\" && $.log = \"*\"}"` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of the Lambda function | `string` | `"cloudwatch-logs-notifier"` | no |
 | <a name="input_log_group_subscriptions"></a> [log\_group\_subscriptions](#input\_log\_group\_subscriptions) | List of CloudWatch log groups to subscribe to | `list(string)` | `[]` | no |
+| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | The Slack channel to send notifications to | `string` | `""` | no |
+| <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | The username to display for Slack notifications | `string` | `"CloudWatch Logs"` | no |
+| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | The Slack webhook URL for notifications | `string` | `""` | no |
 | <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | The name of the SNS topic for notifications | `string` | `"cloudwatch-logs-notifications"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | <pre>{<br/>  "ManagedBy": "terraform"<br/>}</pre> | no |
 
@@ -49,6 +150,8 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudwatch_alarm_sns_topic_arn"></a> [cloudwatch\_alarm\_sns\_topic\_arn](#output\_cloudwatch\_alarm\_sns\_topic\_arn) | The ARN of the SNS topic for CloudWatch alarm notifications |
+| <a name="output_cloudwatch_alarm_sns_topic_name"></a> [cloudwatch\_alarm\_sns\_topic\_name](#output\_cloudwatch\_alarm\_sns\_topic\_name) | The name of the SNS topic for CloudWatch alarm notifications |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group for the Lambda function |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda function |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The invocation ARN of the Lambda function |

--- a/README.md
+++ b/README.md
@@ -1,98 +1,3 @@
-# CloudWatch Logs Notification Module for AWS
-
-[![codecov](https://codecov.io/gh/DevHatRo/terraform-aws-module-cloudwatchlog-notify/graph/badge.svg?token=UPRDDCJZ1P)](https://codecov.io/gh/DevHatRo/terraform-aws-module-cloudwatchlog-notify)
-
-This Terraform module deploys a complete solution for receiving CloudWatch Logs events and sending notifications through SNS.
-
-## Architecture
-
-This module sets up:
-
-1. A Lambda function that processes CloudWatch Logs events
-2. An SNS topic that receives notifications from the Lambda function
-3. CloudWatch Logs subscription filters for the specified log groups
-4. All necessary IAM permissions and policies
-
-The Lambda function supports:
-- Processing CloudWatch Logs events directly
-- Processing events via SNS
-- Parsing JSON log messages, including Kubernetes logs
-- Custom formatting for different log types
-- Processing CloudWatch Alarm notifications
-
-## Features
-
-### Email Notifications
-
-The module can send CloudWatch Logs alerts to email subscribers through Amazon SNS.
-
-```hcl
-module "cloudwatch_logs_notifier" {
-  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-
-  email_subscribers = ["alerts@example.com", "team@example.com"]
-  email_subject     = "AWS CloudWatch Alert"  # Customize the email subject
-  log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
-}
-```
-
-### Slack Notifications
-
-The module can also send CloudWatch Logs alerts to Slack channels through webhooks.
-
-```hcl
-module "cloudwatch_logs_notifier" {
-  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-
-  enable_slack_notifications = true
-  slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-  slack_channel = "#alerts"
-  slack_username = "CloudWatch Logs Bot"
-
-  log_group_subscriptions = ["/aws/lambda/my-function", "/aws/eks/my-cluster/cluster"]
-}
-```
-
-### CloudWatch Alarm SNS Topic
-
-The module can create a dedicated SNS topic for CloudWatch Alarms to trigger the Lambda function. This allows you to have your CloudWatch Alarms send notifications through the same pipeline as your CloudWatch Logs.
-
-```hcl
-module "cloudwatch_logs_notifier" {
-  source = "github.com/username/terraform-aws-module-cloudwatchlog-notify"
-
-  # Enable CloudWatch Alarm SNS Topic
-  create_cloudwatch_alarm_sns_topic = true
-  cloudwatch_alarm_sns_topic_name   = "my-alarm-topic"
-
-  # Configure notification channels
-  enable_slack_notifications = true
-  slack_webhook_url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
-  slack_channel = "#alerts"
-
-  email_subscribers = ["alerts@example.com"]
-}
-
-# Example CloudWatch Alarm that sends to the CloudWatch Alarm SNS topic
-resource "aws_cloudwatch_metric_alarm" "example" {
-  alarm_name          = "example-high-cpu-alarm"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 2
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/Lambda"
-  period              = 60
-  statistic           = "Average"
-  threshold           = 80
-  alarm_description   = "This metric monitors Lambda function CPU utilization"
-  alarm_actions       = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
-  ok_actions          = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
-
-  dimensions = {
-    FunctionName = "my-lambda-function"
-  }
-}
-```
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -111,6 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "example" {
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cloudwatch_alarm_sns"></a> [cloudwatch\_alarm\_sns](#module\_cloudwatch\_alarm\_sns) | terraform-aws-modules/sns/aws | 6.1.3 |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | 7.21.0 |
 | <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 6.1.3 |
 
@@ -134,6 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "example" {
 | <a name="input_create_cloudwatch_log_subscription_filter"></a> [create\_cloudwatch\_log\_subscription\_filter](#input\_create\_cloudwatch\_log\_subscription\_filter) | Whether to create the CloudWatch log subscription filter | `bool` | `true` | no |
 | <a name="input_create_lambda_function"></a> [create\_lambda\_function](#input\_create\_lambda\_function) | Whether to create the Lambda function | `bool` | `true` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create the SNS topic | `bool` | `true` | no |
+| <a name="input_email_subject"></a> [email\_subject](#input\_email\_subject) | The subject line to use for email notifications | `string` | `"CloudWatch Alert"` | no |
 | <a name="input_email_subscribers"></a> [email\_subscribers](#input\_email\_subscribers) | List of email addresses to subscribe to the SNS topic | `list(string)` | `[]` | no |
 | <a name="input_enable_slack_notifications"></a> [enable\_slack\_notifications](#input\_enable\_slack\_notifications) | Whether to enable Slack notifications | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to enable all resources | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,34 +10,115 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = local.region
 }
 
-module "cloudwatch_logs_notifier" {
-  source = "../../"
+locals {
+  region = "us-east-1"
+  name   = "cloudwatch-logs-notifier-example"
 
-  function_name  = "logs-error-notifier"
-  sns_topic_name = "logs-error-alerts"
-
-  # Subscribe these email addresses to the SNS topic
-  email_subscribers = [
-    "alerts@example.com",
-    "devops@example.com"
-  ]
-
-  # Monitor these CloudWatch log groups
-  log_group_subscriptions = [
-    "/aws/eks/my-cluster/application-logs",
-    "/aws/lambda/important-function"
-  ]
-
-  # Custom filter pattern (customize to your needs)
-  filter_pattern = "{$.kubernetes.namespace_name = \"*\" && $.log = \"*error*\"}"
-
-  # Add custom tags
   tags = {
-    Environment = "production"
-    Project     = "monitoring"
-    ManagedBy   = "terraform"
+    Owner       = "user"
+    Environment = "dev"
+    Terraform   = "true"
   }
+}
+
+################################################################################
+# CloudWatch Logs Notifier Module
+################################################################################
+
+module "cloudwatch_logs_notifier" {
+  source = "../.."
+
+  function_name = local.name
+
+  # SNS and Email configuration
+  sns_topic_name    = "${local.name}-topic"
+  email_subscribers = ["alerts@example.com"]
+
+  # Slack configuration
+  enable_slack_notifications = true
+  slack_webhook_url          = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  slack_channel              = "#alerts"
+  slack_username             = "CloudWatch Alert Bot"
+
+  # CloudWatch Logs subscription configuration
+  log_group_subscriptions = [
+    "/aws/lambda/example-function",
+    "/aws/eks/example-cluster/cluster"
+  ]
+
+  # Custom filter pattern for Kubernetes logs with errors
+  filter_pattern = "{$.kubernetes.namespace_name = \"*\" && $.kubernetes.pod_name = \"*\" && $.kubernetes.container_name = \"*\" && $.log = \"*ERROR*\"}"
+
+  # CloudWatch Alarm SNS Topic configuration
+  create_cloudwatch_alarm_sns_topic = true
+  cloudwatch_alarm_sns_topic_name   = "${local.name}-alarms"
+
+  tags = local.tags
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+# Example Lambda function that will be monitored
+module "lambda_function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 7.0"
+
+  function_name = "example-function"
+  description   = "Example Lambda function that will be monitored"
+  handler       = "index.handler"
+  runtime       = "nodejs18.x"
+
+  source_path = "${path.module}/src/example-function"
+
+  tags = local.tags
+}
+
+# Create a dummy log group for the example
+resource "aws_cloudwatch_log_group" "example" {
+  name              = "/aws/eks/example-cluster/cluster"
+  retention_in_days = 1
+
+  tags = local.tags
+}
+
+# Example CloudWatch Alarm that sends to the CloudWatch Alarm SNS topic
+resource "aws_cloudwatch_metric_alarm" "example" {
+  alarm_name          = "example-high-cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "This metric monitors Lambda function CPU utilization"
+  alarm_actions       = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
+  ok_actions          = [module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn]
+
+  dimensions = {
+    FunctionName = module.lambda_function.lambda_function_name
+  }
+
+  tags = local.tags
+}
+
+# Output the module outputs
+output "lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.cloudwatch_logs_notifier.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "The ARN of the SNS topic for CloudWatch log notifications"
+  value       = module.cloudwatch_logs_notifier.sns_topic_arn
+}
+
+output "cloudwatch_alarm_sns_topic_arn" {
+  description = "The ARN of the SNS topic for CloudWatch alarm notifications"
+  value       = module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -106,19 +106,3 @@ resource "aws_cloudwatch_metric_alarm" "example" {
 
   tags = local.tags
 }
-
-# Output the module outputs
-output "lambda_function_name" {
-  description = "The name of the Lambda function"
-  value       = module.cloudwatch_logs_notifier.lambda_function_name
-}
-
-output "sns_topic_arn" {
-  description = "The ARN of the SNS topic for CloudWatch log notifications"
-  value       = module.cloudwatch_logs_notifier.sns_topic_arn
-}
-
-output "cloudwatch_alarm_sns_topic_arn" {
-  description = "The ARN of the SNS topic for CloudWatch alarm notifications"
-  value       = module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn
-}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -7,3 +7,18 @@ output "sns_topic_arn" {
   description = "ARN of the created SNS topic"
   value       = module.cloudwatch_logs_notifier.sns_topic_arn
 }
+
+output "lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.cloudwatch_logs_notifier.lambda_function_name
+}
+
+output "sns_topic_arn" {
+  description = "The ARN of the SNS topic for CloudWatch log notifications"
+  value       = module.cloudwatch_logs_notifier.sns_topic_arn
+}
+
+output "cloudwatch_alarm_sns_topic_arn" {
+  description = "The ARN of the SNS topic for CloudWatch alarm notifications"
+  value       = module.cloudwatch_logs_notifier.cloudwatch_alarm_sns_topic_arn
+}

--- a/functions/lambda_function.py
+++ b/functions/lambda_function.py
@@ -3,6 +3,7 @@ import gzip
 import json
 import logging
 import os
+import urllib.request
 
 import boto3
 from botocore.exceptions import ClientError
@@ -38,8 +39,20 @@ def lambda_handler(event, context):
                 sns_message = record.get('Sns', {}).get('Message')
                 if sns_message:
                     try:
+                        # Try to parse the message as JSON
                         sns_data = json.loads(sns_message)
-                        process_cloudwatch_log_event(sns_data, sns_arn)
+                        
+                        # Check if this is a CloudWatch Alarm
+                        if 'AlarmName' in sns_data:
+                            logger.info("Processing CloudWatch Alarm notification")
+                            process_cloudwatch_alarm(sns_data, sns_arn)
+                        # If it has awslogs data, it's a CloudWatch Logs event
+                        elif 'awslogs' in sns_data:
+                            logger.info("Processing CloudWatch Logs notification from SNS")
+                            process_cloudwatch_log_event(sns_data, sns_arn)
+                        else:
+                            logger.info("Processing generic SNS notification")
+                            process_generic_sns_message(sns_data, sns_arn)
                     except json.JSONDecodeError:
                         logger.error("Failed to parse SNS message as JSON: %s", sns_message)
                         return {
@@ -60,6 +73,112 @@ def lambda_handler(event, context):
         'statusCode': 200,
         'body': json.dumps('Successfully processed CloudWatch Logs')
     }
+
+def process_cloudwatch_alarm(alarm_data, sns_arn):
+    """
+    Process CloudWatch Alarm data and forward to SNS/Slack.
+
+    Args:
+        alarm_data (dict): CloudWatch Alarm data
+        sns_arn (str): SNS topic ARN to send notifications to
+    """
+    try:
+        # Extract basic alarm information
+        alarm_name = alarm_data.get('AlarmName', 'Unknown Alarm')
+        alarm_description = alarm_data.get('AlarmDescription', 'No description')
+        alarm_reason = alarm_data.get('NewStateReason', 'No reason provided')
+        alarm_state = alarm_data.get('NewStateValue', 'UNKNOWN')
+        region = alarm_data.get('Region', 'unknown-region')
+        
+        # Create notification message for email
+        notification_message = (
+            f"CloudWatch Alarm: {alarm_name}\n\n"
+            f"State: {alarm_state}\n"
+            f"Description: {alarm_description}\n"
+            f"Region: {region}\n\n"
+            f"Reason: {alarm_reason}\n\n"
+            f"Details: {json.dumps(alarm_data, indent=2)}"
+        )
+
+        # Create Slack message
+        color = "danger" if alarm_state == "ALARM" else "good" if alarm_state == "OK" else "warning"
+        slack_message = {
+            "attachments": [{
+                "color": color,
+                "title": f"CloudWatch Alarm: {alarm_name}",
+                "fields": [
+                    {"title": "State", "value": alarm_state, "short": True},
+                    {"title": "Region", "value": region, "short": True},
+                    {"title": "Description", "value": alarm_description, "short": False},
+                    {"title": "Reason", "value": alarm_reason, "short": False}
+                ]
+            }]
+        }
+
+        # Send to SNS
+        send_to_sns(notification_message, sns_arn)
+
+        # Send to Slack if enabled
+        if os.environ.get('ENABLE_SLACK', 'false').lower() == 'true':
+            slack_webhook_url = os.environ.get('SLACK_WEBHOOK_URL')
+            if slack_webhook_url:
+                # Add channel if specified
+                slack_channel = os.environ.get('SLACK_CHANNEL')
+                if slack_channel:
+                    slack_message['channel'] = slack_channel
+                
+                # Add username if specified
+                slack_username = os.environ.get('SLACK_USERNAME')
+                if slack_username:
+                    slack_message['username'] = slack_username
+                
+                send_to_slack(slack_message, slack_webhook_url)
+
+    except Exception as e:
+        logger.error("Error processing CloudWatch Alarm: %s", str(e))
+
+def process_generic_sns_message(sns_data, sns_arn):
+    """
+    Process a generic SNS message and forward it.
+
+    Args:
+        sns_data (dict): The SNS message data
+        sns_arn (str): SNS topic ARN to send notifications to
+    """
+    try:
+        # Create a simple message from the data
+        notification_message = f"SNS Notification:\n\n{json.dumps(sns_data, indent=2)}"
+        
+        # Create Slack message
+        slack_message = {
+            "attachments": [{
+                "color": "good",
+                "title": "SNS Notification",
+                "text": json.dumps(sns_data, indent=2)
+            }]
+        }
+
+        # Send to SNS
+        send_to_sns(notification_message, sns_arn)
+
+        # Send to Slack if enabled
+        if os.environ.get('ENABLE_SLACK', 'false').lower() == 'true':
+            slack_webhook_url = os.environ.get('SLACK_WEBHOOK_URL')
+            if slack_webhook_url:
+                # Add channel if specified
+                slack_channel = os.environ.get('SLACK_CHANNEL')
+                if slack_channel:
+                    slack_message['channel'] = slack_channel
+                
+                # Add username if specified
+                slack_username = os.environ.get('SLACK_USERNAME')
+                if slack_username:
+                    slack_message['username'] = slack_username
+                
+                send_to_slack(slack_message, slack_webhook_url)
+    
+    except Exception as e:
+        logger.error("Error processing generic SNS message: %s", str(e))
 
 def process_cloudwatch_log_event(event, sns_arn):
     """
@@ -119,6 +238,21 @@ def process_cloudwatch_log_event(event, sns_arn):
                         f"Log Stream: {log_stream}\n\n"
                         f"Message: {log_content}"
                     )
+
+                    slack_message = {
+                        "attachments": [{
+                            "color": "danger",
+                            "title": f"Error in Kubernetes: {namespace}/{pod}",
+                            "fields": [
+                                {"title": "Namespace", "value": namespace, "short": True},
+                                {"title": "Pod", "value": pod, "short": True},
+                                {"title": "Container", "value": container, "short": True},
+                                {"title": "Log Group", "value": log_group, "short": True},
+                                {"title": "Log Stream", "value": log_stream, "short": True},
+                                {"title": "Message", "value": log_content, "short": False}
+                            ]
+                        }]
+                    }
                 else:
                     notification_message = (
                         f"Error detected in logs:\n\n"
@@ -126,6 +260,18 @@ def process_cloudwatch_log_event(event, sns_arn):
                         f"Log Stream: {log_stream}\n\n"
                         f"Message: {json.dumps(message_json, indent=2)}"
                     )
+
+                    slack_message = {
+                        "attachments": [{
+                            "color": "danger",
+                            "title": f"Error in {log_group}",
+                            "fields": [
+                                {"title": "Log Group", "value": log_group, "short": True},
+                                {"title": "Log Stream", "value": log_stream, "short": True},
+                                {"title": "Message", "value": json.dumps(message_json, indent=2), "short": False}
+                            ]
+                        }]
+                    }
             except json.JSONDecodeError:
                 # Not JSON, use raw message
                 notification_message = (
@@ -135,8 +281,36 @@ def process_cloudwatch_log_event(event, sns_arn):
                     f"Message: {message}"
                 )
 
+                slack_message = {
+                    "attachments": [{
+                        "color": "danger",
+                        "title": f"Error in {log_group}",
+                        "fields": [
+                            {"title": "Log Group", "value": log_group, "short": True},
+                            {"title": "Log Stream", "value": log_stream, "short": True},
+                            {"title": "Message", "value": message, "short": False}
+                        ]
+                    }]
+                }
+
             # Send to SNS
             send_to_sns(notification_message, sns_arn)
+
+            # Send to Slack if enabled
+            if os.environ.get('ENABLE_SLACK', 'false').lower() == 'true':
+                slack_webhook_url = os.environ.get('SLACK_WEBHOOK_URL')
+                if slack_webhook_url:
+                    # Add channel if specified
+                    slack_channel = os.environ.get('SLACK_CHANNEL')
+                    if slack_channel:
+                        slack_message['channel'] = slack_channel
+                    
+                    # Add username if specified
+                    slack_username = os.environ.get('SLACK_USERNAME')
+                    if slack_username:
+                        slack_message['username'] = slack_username
+                    
+                    send_to_slack(slack_message, slack_webhook_url)
 
         except Exception as e:
             logger.error("Error processing log event: %s", str(e))
@@ -150,11 +324,35 @@ def send_to_sns(message, sns_arn):
         sns_arn (str): SNS topic ARN
     """
     try:
+        # Get email subject from environment variable with fallback
+        email_subject = os.environ.get('EMAIL_SUBJECT', 'CloudWatch Alert')
+        
         response = sns_client.publish(
             TopicArn=sns_arn,
             Message=message,
-            Subject="CloudWatch Logs Alert"
+            Subject=email_subject
         )
         logger.info("Message sent to SNS: %s", response['MessageId'])
     except ClientError as e:
         logger.error("Failed to send message to SNS: %s", str(e))
+
+def send_to_slack(message, webhook_url):
+    """
+    Send a message to a Slack webhook.
+
+    Args:
+        message (dict): Slack-formatted message to send
+        webhook_url (str): Slack webhook URL
+    """
+    try:
+        data = json.dumps(message).encode('utf-8')
+        headers = {'Content-Type': 'application/json'}
+        req = urllib.request.Request(webhook_url, data=data, headers=headers)
+        
+        with urllib.request.urlopen(req) as response:
+            if response.status != 200:
+                logger.error("Failed to send message to Slack. Status code: %s", response.status)
+            else:
+                logger.info("Message sent to Slack successfully")
+    except Exception as e:
+        logger.error("Error sending message to Slack: %s", str(e))

--- a/functions/lambda_function.py
+++ b/functions/lambda_function.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
                     try:
                         # Try to parse the message as JSON
                         sns_data = json.loads(sns_message)
-                        
+
                         # Check if this is a CloudWatch Alarm
                         if 'AlarmName' in sns_data:
                             logger.info("Processing CloudWatch Alarm notification")
@@ -89,7 +89,7 @@ def process_cloudwatch_alarm(alarm_data, sns_arn):
         alarm_reason = alarm_data.get('NewStateReason', 'No reason provided')
         alarm_state = alarm_data.get('NewStateValue', 'UNKNOWN')
         region = alarm_data.get('Region', 'unknown-region')
-        
+
         # Create notification message for email
         notification_message = (
             f"CloudWatch Alarm: {alarm_name}\n\n"
@@ -126,12 +126,12 @@ def process_cloudwatch_alarm(alarm_data, sns_arn):
                 slack_channel = os.environ.get('SLACK_CHANNEL')
                 if slack_channel:
                     slack_message['channel'] = slack_channel
-                
+
                 # Add username if specified
                 slack_username = os.environ.get('SLACK_USERNAME')
                 if slack_username:
                     slack_message['username'] = slack_username
-                
+
                 send_to_slack(slack_message, slack_webhook_url)
 
     except Exception as e:
@@ -148,7 +148,7 @@ def process_generic_sns_message(sns_data, sns_arn):
     try:
         # Create a simple message from the data
         notification_message = f"SNS Notification:\n\n{json.dumps(sns_data, indent=2)}"
-        
+
         # Create Slack message
         slack_message = {
             "attachments": [{
@@ -169,14 +169,14 @@ def process_generic_sns_message(sns_data, sns_arn):
                 slack_channel = os.environ.get('SLACK_CHANNEL')
                 if slack_channel:
                     slack_message['channel'] = slack_channel
-                
+
                 # Add username if specified
                 slack_username = os.environ.get('SLACK_USERNAME')
                 if slack_username:
                     slack_message['username'] = slack_username
-                
+
                 send_to_slack(slack_message, slack_webhook_url)
-    
+
     except Exception as e:
         logger.error("Error processing generic SNS message: %s", str(e))
 
@@ -304,12 +304,12 @@ def process_cloudwatch_log_event(event, sns_arn):
                     slack_channel = os.environ.get('SLACK_CHANNEL')
                     if slack_channel:
                         slack_message['channel'] = slack_channel
-                    
+
                     # Add username if specified
                     slack_username = os.environ.get('SLACK_USERNAME')
                     if slack_username:
                         slack_message['username'] = slack_username
-                    
+
                     send_to_slack(slack_message, slack_webhook_url)
 
         except Exception as e:
@@ -326,7 +326,7 @@ def send_to_sns(message, sns_arn):
     try:
         # Get email subject from environment variable with fallback
         email_subject = os.environ.get('EMAIL_SUBJECT', 'CloudWatch Alert')
-        
+
         response = sns_client.publish(
             TopicArn=sns_arn,
             Message=message,
@@ -348,7 +348,7 @@ def send_to_slack(message, webhook_url):
         data = json.dumps(message).encode('utf-8')
         headers = {'Content-Type': 'application/json'}
         req = urllib.request.Request(webhook_url, data=data, headers=headers)
-        
+
         with urllib.request.urlopen(req) as response:
             if response.status != 200:
                 logger.error("Failed to send message to Slack. Status code: %s", response.status)

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -229,7 +229,7 @@ class TestLambdaFunction(unittest.TestCase):
     @patch('lambda_function.sns_client')
     def test_lambda_handler_unknown_event(self, mock_sns_client):
         """Test handling an unknown event format"""
-        # Create an event with unknown format
+        # Create an event with an unknown format
         event = {
             "some_key": "some_value"
         }
@@ -237,12 +237,309 @@ class TestLambdaFunction(unittest.TestCase):
         # Call the Lambda handler
         result = lambda_function.lambda_handler(event, {})
 
+        # Check the response
+        self.assertEqual(result['statusCode'], 400)
+        self.assertEqual(json.loads(result['body']), 'Unknown event format')
+
         # Check that SNS publish was not called
         mock_sns_client.publish.assert_not_called()
 
-        # Check the response has error status code
-        self.assertEqual(result['statusCode'], 400)
-        self.assertEqual(json.loads(result['body']), 'Unknown event format')
+    @patch('lambda_function.sns_client')
+    @patch('lambda_function.urllib.request.Request')
+    @patch('lambda_function.urllib.request.urlopen')
+    def test_slack_notification_enabled(self, mock_urlopen, mock_request, mock_sns_client):
+        """Test sending notifications to Slack when enabled"""
+        # Set environment variables for Slack
+        os.environ['ENABLE_SLACK'] = 'true'
+        os.environ['SLACK_WEBHOOK_URL'] = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+        os.environ['SLACK_CHANNEL'] = '#test-channel'
+        os.environ['SLACK_USERNAME'] = 'CloudWatch-Bot'
+
+        # Configure mocks
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        mock_sns_client.publish.return_value = {'MessageId': 'test-message-id'}
+
+        # Create a test event with a regular log message
+        event = self.create_test_cw_logs_event("This is a test error message")
+
+        # Call the Lambda handler
+        result = lambda_function.lambda_handler(event, {})
+
+        # Check if SNS publish was called
+        mock_sns_client.publish.assert_called_once()
+
+        # Check if Slack webhook was called
+        mock_request.assert_called_once()
+        mock_urlopen.assert_called_once()
+
+        # Verify that the Slack message contains the expected fields
+        request_args = mock_request.call_args[1]
+        self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
+        self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
+        
+        # Parse the data to check fields
+        data = json.loads(request_args['data'].decode('utf-8'))
+        self.assertEqual(data['channel'], '#test-channel')
+        self.assertEqual(data['username'], 'CloudWatch-Bot')
+        self.assertTrue('attachments' in data)
+
+        # Check the response
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
+
+        # Clean up
+        del os.environ['ENABLE_SLACK']
+        del os.environ['SLACK_WEBHOOK_URL']
+        del os.environ['SLACK_CHANNEL']
+        del os.environ['SLACK_USERNAME']
+
+    @patch('lambda_function.sns_client')
+    @patch('lambda_function.urllib.request')
+    def test_slack_notification_disabled(self, mock_urllib_request, mock_sns_client):
+        """Test that Slack notifications are not sent when disabled"""
+        # Set environment variables for Slack (disabled)
+        os.environ['ENABLE_SLACK'] = 'false'
+        os.environ['SLACK_WEBHOOK_URL'] = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+
+        # Configure mocks
+        mock_sns_client.publish.return_value = {'MessageId': 'test-message-id'}
+
+        # Create a test event with a regular log message
+        event = self.create_test_cw_logs_event("This is a test error message")
+
+        # Call the Lambda handler
+        result = lambda_function.lambda_handler(event, {})
+
+        # Check if SNS publish was called
+        mock_sns_client.publish.assert_called_once()
+
+        # Check that urllib.request was not used (no Slack call)
+        mock_urllib_request.Request.assert_not_called()
+
+        # Check the response
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
+
+        # Clean up
+        del os.environ['ENABLE_SLACK']
+        del os.environ['SLACK_WEBHOOK_URL']
+
+    @patch('lambda_function.sns_client')
+    @patch('lambda_function.urllib.request.Request')
+    @patch('lambda_function.urllib.request.urlopen')
+    def test_slack_error_handling(self, mock_urlopen, mock_request, mock_sns_client):
+        """Test handling errors during Slack notification"""
+        # Set environment variables for Slack
+        os.environ['ENABLE_SLACK'] = 'true'
+        os.environ['SLACK_WEBHOOK_URL'] = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+
+        # Configure mocks
+        mock_response = MagicMock()
+        mock_response.status = 400  # Error status
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        mock_sns_client.publish.return_value = {'MessageId': 'test-message-id'}
+
+        # Create a test event with a regular log message
+        event = self.create_test_cw_logs_event("This is a test error message")
+
+        # Call the Lambda handler
+        result = lambda_function.lambda_handler(event, {})
+
+        # Check if SNS publish was called
+        mock_sns_client.publish.assert_called_once()
+
+        # Check if Slack webhook was called
+        mock_request.assert_called_once()
+        mock_urlopen.assert_called_once()
+
+        # Check the response (should still be 200 despite Slack error)
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
+
+        # Clean up
+        del os.environ['ENABLE_SLACK']
+        del os.environ['SLACK_WEBHOOK_URL']
+
+    @patch('lambda_function.sns_client')
+    def test_lambda_handler_cloudwatch_alarm(self, mock_sns_client):
+        """Test handling a CloudWatch Alarm event"""
+        # Create a CloudWatch Alarm message
+        cloudwatch_alarm = {
+            "AlarmName": "test-alarm",
+            "AlarmDescription": "This is a test alarm",
+            "AWSAccountId": "123456789012",
+            "NewStateValue": "ALARM",
+            "NewStateReason": "Threshold Crossed",
+            "StateChangeTime": "2023-01-01T00:00:00.000+0000",
+            "Region": "us-east-1",
+            "OldStateValue": "OK",
+            "Trigger": {
+                "MetricName": "CPUUtilization",
+                "Namespace": "AWS/EC2",
+                "StatisticType": "Statistic",
+                "Statistic": "AVERAGE",
+                "Unit": null,
+                "Dimensions": [],
+                "Period": 300,
+                "EvaluationPeriods": 1,
+                "ComparisonOperator": "GreaterThanThreshold",
+                "Threshold": 80.0
+            }
+        }
+        
+        # Wrap it in an SNS event
+        sns_message = json.dumps(cloudwatch_alarm)
+        event = {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "EventVersion": "1.0",
+                    "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:test-topic:subscription-id",
+                    "Sns": {
+                        "Type": "Notification",
+                        "MessageId": "12345678-1234-1234-1234-123456789012",
+                        "TopicArn": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                        "Subject": "Test Subject",
+                        "Message": sns_message,
+                        "Timestamp": "2023-01-01T00:00:00.000Z",
+                        "SignatureVersion": "1",
+                        "Signature": "test-signature",
+                        "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345.pem",
+                        "UnsubscribeUrl": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:test-topic:subscription-id",
+                        "MessageAttributes": {}
+                    }
+                }
+            ]
+        }
+
+        # Mock the SNS publish response
+        mock_sns_client.publish.return_value = {'MessageId': 'test-message-id'}
+
+        # Call the Lambda handler
+        result = lambda_function.lambda_handler(event, {})
+
+        # Check if SNS publish was called
+        mock_sns_client.publish.assert_called_once()
+        
+        # Verify the correct subject was used
+        self.assertEqual(mock_sns_client.publish.call_args[1]['Subject'], 'CloudWatch Alert')
+
+        # Check the response
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
+        
+    @patch('lambda_function.sns_client')
+    @patch('lambda_function.urllib.request.Request')
+    @patch('lambda_function.urllib.request.urlopen')
+    def test_cloudwatch_alarm_with_slack(self, mock_urlopen, mock_request, mock_sns_client):
+        """Test handling a CloudWatch Alarm with Slack enabled"""
+        # Set environment variables for Slack
+        os.environ['ENABLE_SLACK'] = 'true'
+        os.environ['SLACK_WEBHOOK_URL'] = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+        os.environ['SLACK_CHANNEL'] = '#test-channel'
+        os.environ['SLACK_USERNAME'] = 'CloudWatch-Bot'
+
+        # Configure mocks
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        mock_sns_client.publish.return_value = {'MessageId': 'test-message-id'}
+
+        # Create a CloudWatch Alarm message
+        cloudwatch_alarm = {
+            "AlarmName": "test-alarm",
+            "AlarmDescription": "This is a test alarm",
+            "AWSAccountId": "123456789012",
+            "NewStateValue": "ALARM",
+            "NewStateReason": "Threshold Crossed",
+            "StateChangeTime": "2023-01-01T00:00:00.000+0000",
+            "Region": "us-east-1",
+            "OldStateValue": "OK",
+            "Trigger": {
+                "MetricName": "CPUUtilization",
+                "Namespace": "AWS/EC2",
+                "StatisticType": "Statistic",
+                "Statistic": "AVERAGE",
+                "Unit": null,
+                "Dimensions": [],
+                "Period": 300,
+                "EvaluationPeriods": 1,
+                "ComparisonOperator": "GreaterThanThreshold",
+                "Threshold": 80.0
+            }
+        }
+        
+        # Wrap it in an SNS event
+        sns_message = json.dumps(cloudwatch_alarm)
+        event = {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "EventVersion": "1.0",
+                    "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:test-topic:subscription-id",
+                    "Sns": {
+                        "Type": "Notification",
+                        "MessageId": "12345678-1234-1234-1234-123456789012",
+                        "TopicArn": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                        "Subject": "Test Subject",
+                        "Message": sns_message,
+                        "Timestamp": "2023-01-01T00:00:00.000Z",
+                        "SignatureVersion": "1",
+                        "Signature": "test-signature",
+                        "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-12345.pem",
+                        "UnsubscribeUrl": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:test-topic:subscription-id",
+                        "MessageAttributes": {}
+                    }
+                }
+            ]
+        }
+
+        # Call the Lambda handler
+        result = lambda_function.lambda_handler(event, {})
+
+        # Check if SNS publish was called
+        mock_sns_client.publish.assert_called_once()
+
+        # Check if Slack webhook was called
+        mock_request.assert_called_once()
+        mock_urlopen.assert_called_once()
+
+        # Verify that the Slack message contains the expected fields
+        request_args = mock_request.call_args[1]
+        self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
+        self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
+        
+        # Parse the data to check fields
+        data = json.loads(request_args['data'].decode('utf-8'))
+        self.assertEqual(data['channel'], '#test-channel')
+        self.assertEqual(data['username'], 'CloudWatch-Bot')
+        self.assertTrue('attachments' in data)
+        
+        # Verify the alarm specific fields
+        attachment = data['attachments'][0]
+        self.assertEqual(attachment['color'], 'danger')  # ALARM state
+        self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
+        
+        # Find fields by title
+        fields = attachment['fields']
+        state_field = next((f for f in fields if f['title'] == 'State'), None)
+        self.assertIsNotNone(state_field)
+        self.assertEqual(state_field['value'], 'ALARM')
+
+        # Check the response
+        self.assertEqual(result['statusCode'], 200)
+        self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
+
+        # Clean up
+        del os.environ['ENABLE_SLACK']
+        del os.environ['SLACK_WEBHOOK_URL']
+        del os.environ['SLACK_CHANNEL']
+        del os.environ['SLACK_USERNAME']
 
 
 if __name__ == '__main__':

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -278,7 +278,7 @@ class TestLambdaFunction(unittest.TestCase):
         # Verify that the Slack message contains the expected fields
         mock_request.assert_called_with(
             os.environ['SLACK_WEBHOOK_URL'],
-            json.dumps({
+            data=json.dumps({
                 'channel': '#test-channel',
                 'username': 'CloudWatch-Bot',
                 'attachments': [{
@@ -291,7 +291,7 @@ class TestLambdaFunction(unittest.TestCase):
                     ]
                 }]
             }).encode('utf-8'),
-            {'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'}
         )
 
         # Check the response
@@ -521,7 +521,7 @@ class TestLambdaFunction(unittest.TestCase):
         # Verify that the Slack message contains the expected fields
         mock_request.assert_called_with(
             os.environ['SLACK_WEBHOOK_URL'],
-            json.dumps({
+            data=json.dumps({
                 'channel': '#test-channel',
                 'username': 'CloudWatch-Bot',
                 'attachments': [{
@@ -535,7 +535,7 @@ class TestLambdaFunction(unittest.TestCase):
                     ]
                 }]
             }).encode('utf-8'),
-            {'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'}
         )
 
         # Check the response

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -275,24 +275,29 @@ class TestLambdaFunction(unittest.TestCase):
         mock_request.assert_called_once()
         mock_urlopen.assert_called_once()
 
-        # Verify that the Slack message contains the expected fields
-        mock_request.assert_called_with(
-            os.environ['SLACK_WEBHOOK_URL'],
-            data=json.dumps({
-                'channel': '#test-channel',
-                'username': 'CloudWatch-Bot',
-                'attachments': [{
-                    'color': 'danger',
-                    'title': 'Error in /aws/lambda/test-function',
-                    'fields': [
-                        {'title': 'Log Group', 'value': '/aws/lambda/test-function', 'short': True},
-                        {'title': 'Log Stream', 'value': 'test-stream', 'short': True},
-                        {'title': 'Message', 'value': 'This is a test error message', 'short': False}
-                    ]
-                }]
-            }).encode('utf-8'),
-            headers={'Content-Type': 'application/json'}
-        )
+        # Get the actual call arguments
+        call_args = mock_request.call_args
+        actual_data = json.loads(call_args[1]['data'].decode('utf-8'))
+
+        # Verify the structure of the Slack message
+        self.assertEqual(actual_data['channel'], '#test-channel')
+        self.assertEqual(actual_data['username'], 'CloudWatch-Bot')
+        self.assertTrue('attachments' in actual_data)
+        
+        # Verify the attachment structure
+        attachment = actual_data['attachments'][0]
+        self.assertEqual(attachment['color'], 'danger')
+        self.assertEqual(attachment['title'], 'Error in /aws/lambda/test-function')
+        
+        # Verify the fields
+        fields = attachment['fields']
+        self.assertEqual(len(fields), 3)
+        self.assertEqual(fields[0]['title'], 'Log Group')
+        self.assertEqual(fields[0]['value'], '/aws/lambda/test-function')
+        self.assertEqual(fields[1]['title'], 'Log Stream')
+        self.assertEqual(fields[1]['value'], 'test-stream')
+        self.assertEqual(fields[2]['title'], 'Message')
+        self.assertEqual(fields[2]['value'], 'This is a test error message')
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
@@ -518,25 +523,40 @@ class TestLambdaFunction(unittest.TestCase):
         mock_request.assert_called_once()
         mock_urlopen.assert_called_once()
 
-        # Verify that the Slack message contains the expected fields
-        mock_request.assert_called_with(
-            os.environ['SLACK_WEBHOOK_URL'],
-            data=json.dumps({
-                'channel': '#test-channel',
-                'username': 'CloudWatch-Bot',
-                'attachments': [{
-                    'color': 'danger',
-                    'title': 'CloudWatch Alarm: test-alarm',
-                    'fields': [
-                        {'title': 'State', 'value': 'ALARM', 'short': True},
-                        {'title': 'Region', 'value': 'us-east-1', 'short': True},
-                        {'title': 'Description', 'value': 'This is a test alarm', 'short': False},
-                        {'title': 'Reason', 'value': 'Threshold Crossed', 'short': False}
-                    ]
-                }]
-            }).encode('utf-8'),
-            headers={'Content-Type': 'application/json'}
-        )
+        # Get the actual call arguments
+        call_args = mock_request.call_args
+        actual_data = json.loads(call_args[1]['data'].decode('utf-8'))
+
+        # Verify the structure of the Slack message
+        self.assertEqual(actual_data['channel'], '#test-channel')
+        self.assertEqual(actual_data['username'], 'CloudWatch-Bot')
+        self.assertTrue('attachments' in actual_data)
+        
+        # Verify the attachment structure
+        attachment = actual_data['attachments'][0]
+        self.assertEqual(attachment['color'], 'danger')
+        self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
+        
+        # Verify the fields
+        fields = attachment['fields']
+        self.assertEqual(len(fields), 4)
+        
+        # Find fields by title
+        state_field = next((f for f in fields if f['title'] == 'State'), None)
+        self.assertIsNotNone(state_field)
+        self.assertEqual(state_field['value'], 'ALARM')
+        
+        region_field = next((f for f in fields if f['title'] == 'Region'), None)
+        self.assertIsNotNone(region_field)
+        self.assertEqual(region_field['value'], 'us-east-1')
+        
+        desc_field = next((f for f in fields if f['title'] == 'Description'), None)
+        self.assertIsNotNone(desc_field)
+        self.assertEqual(desc_field['value'], 'This is a test alarm')
+        
+        reason_field = next((f for f in fields if f['title'] == 'Reason'), None)
+        self.assertIsNotNone(reason_field)
+        self.assertEqual(reason_field['value'], 'Threshold Crossed')
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -276,21 +276,33 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        request_args = mock_request.call_args[0]  # Changed from [1] to [0] to get positional arguments
-        self.assertEqual(request_args[0], os.environ['SLACK_WEBHOOK_URL'])  # First positional arg is URL
-        self.assertEqual(request_args[1].decode('utf-8'), json.dumps({
-            'channel': '#test-channel',
-            'username': 'CloudWatch-Bot',
-            'attachments': [{
-                'color': 'danger',
-                'title': 'Error in /aws/lambda/test-function',
-                'fields': [
-                    {'title': 'Log Group', 'value': '/aws/lambda/test-function', 'short': True},
-                    {'title': 'Log Stream', 'value': 'test-stream', 'short': True},
-                    {'title': 'Message', 'value': 'This is a test error message', 'short': False}
-                ]
-            }]
-        }))
+        call_args = mock_request.call_args
+        self.assertIsNotNone(call_args)
+        
+        # Get the positional arguments
+        args, kwargs = call_args
+        self.assertEqual(args[0], os.environ['SLACK_WEBHOOK_URL'])
+        
+        # Verify the request data
+        data = json.loads(args[1].decode('utf-8'))
+        self.assertEqual(data['channel'], '#test-channel')
+        self.assertEqual(data['username'], 'CloudWatch-Bot')
+        self.assertTrue('attachments' in data)
+        
+        # Verify the attachment structure
+        attachment = data['attachments'][0]
+        self.assertEqual(attachment['color'], 'danger')
+        self.assertEqual(attachment['title'], 'Error in /aws/lambda/test-function')
+        
+        # Verify the fields
+        fields = attachment['fields']
+        self.assertEqual(len(fields), 3)
+        self.assertEqual(fields[0]['title'], 'Log Group')
+        self.assertEqual(fields[0]['value'], '/aws/lambda/test-function')
+        self.assertEqual(fields[1]['title'], 'Log Stream')
+        self.assertEqual(fields[1]['value'], 'test-stream')
+        self.assertEqual(fields[2]['title'], 'Message')
+        self.assertEqual(fields[2]['value'], 'This is a test error message')
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
@@ -517,11 +529,15 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        request_args = mock_request.call_args[0]  # Changed from [1] to [0] to get positional arguments
-        self.assertEqual(request_args[0], os.environ['SLACK_WEBHOOK_URL'])  # First positional arg is URL
+        call_args = mock_request.call_args
+        self.assertIsNotNone(call_args)
         
-        # Parse the data to check fields
-        data = json.loads(request_args[1].decode('utf-8'))
+        # Get the positional arguments
+        args, kwargs = call_args
+        self.assertEqual(args[0], os.environ['SLACK_WEBHOOK_URL'])
+        
+        # Verify the request data
+        data = json.loads(args[1].decode('utf-8'))
         self.assertEqual(data['channel'], '#test-channel')
         self.assertEqual(data['username'], 'CloudWatch-Bot')
         self.assertTrue('attachments' in data)

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -276,15 +276,21 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        request_args = mock_request.call_args[1]
-        self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
-        self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
-
-        # Parse the data to check fields
-        data = json.loads(request_args['data'].decode('utf-8'))
-        self.assertEqual(data['channel'], '#test-channel')
-        self.assertEqual(data['username'], 'CloudWatch-Bot')
-        self.assertTrue('attachments' in data)
+        request_args = mock_request.call_args[0]  # Changed from [1] to [0] to get positional arguments
+        self.assertEqual(request_args[0], os.environ['SLACK_WEBHOOK_URL'])  # First positional arg is URL
+        self.assertEqual(request_args[1].decode('utf-8'), json.dumps({
+            'channel': '#test-channel',
+            'username': 'CloudWatch-Bot',
+            'attachments': [{
+                'color': 'danger',
+                'title': 'Error in /aws/lambda/test-function',
+                'fields': [
+                    {'title': 'Log Group', 'value': '/aws/lambda/test-function', 'short': True},
+                    {'title': 'Log Stream', 'value': 'test-stream', 'short': True},
+                    {'title': 'Message', 'value': 'This is a test error message', 'short': False}
+                ]
+            }]
+        }))
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
@@ -297,8 +303,9 @@ class TestLambdaFunction(unittest.TestCase):
         del os.environ['SLACK_USERNAME']
 
     @patch('lambda_function.sns_client')
-    @patch('lambda_function.urllib.request')
-    def test_slack_notification_disabled(self, mock_urllib_request, mock_sns_client):
+    @patch('lambda_function.urllib.request.Request')
+    @patch('lambda_function.urllib.request.urlopen')
+    def test_slack_notification_disabled(self, mock_urlopen, mock_request, mock_sns_client):
         """Test that Slack notifications are not sent when disabled"""
         # Set environment variables for Slack (disabled)
         os.environ['ENABLE_SLACK'] = 'false'
@@ -317,7 +324,7 @@ class TestLambdaFunction(unittest.TestCase):
         mock_sns_client.publish.assert_called_once()
 
         # Check that urllib.request was not used (no Slack call)
-        mock_urllib_request.Request.assert_not_called()
+        mock_urlopen.assert_not_called()
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
@@ -382,7 +389,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Namespace": "AWS/EC2",
                 "StatisticType": "Statistic",
                 "Statistic": "AVERAGE",
-                "Unit": null,
+                "Unit": None,
                 "Dimensions": [],
                 "Period": 300,
                 "EvaluationPeriods": 1,
@@ -390,7 +397,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-
+        
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -424,7 +431,7 @@ class TestLambdaFunction(unittest.TestCase):
 
         # Check if SNS publish was called
         mock_sns_client.publish.assert_called_once()
-
+        
         # Verify the correct subject was used
         self.assertEqual(mock_sns_client.publish.call_args[1]['Subject'], 'CloudWatch Alert')
 
@@ -465,7 +472,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Namespace": "AWS/EC2",
                 "StatisticType": "Statistic",
                 "Statistic": "AVERAGE",
-                "Unit": null,
+                "Unit": None,
                 "Dimensions": [],
                 "Period": 300,
                 "EvaluationPeriods": 1,
@@ -473,7 +480,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-
+        
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -510,21 +517,20 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        request_args = mock_request.call_args[1]
-        self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
-        self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
-
+        request_args = mock_request.call_args[0]  # Changed from [1] to [0] to get positional arguments
+        self.assertEqual(request_args[0], os.environ['SLACK_WEBHOOK_URL'])  # First positional arg is URL
+        
         # Parse the data to check fields
-        data = json.loads(request_args['data'].decode('utf-8'))
+        data = json.loads(request_args[1].decode('utf-8'))
         self.assertEqual(data['channel'], '#test-channel')
         self.assertEqual(data['username'], 'CloudWatch-Bot')
         self.assertTrue('attachments' in data)
-
+        
         # Verify the alarm specific fields
         attachment = data['attachments'][0]
         self.assertEqual(attachment['color'], 'danger')  # ALARM state
         self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
-
+        
         # Find fields by title
         fields = attachment['fields']
         state_field = next((f for f in fields if f['title'] == 'State'), None)

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -283,12 +283,12 @@ class TestLambdaFunction(unittest.TestCase):
         self.assertEqual(actual_data['channel'], '#test-channel')
         self.assertEqual(actual_data['username'], 'CloudWatch-Bot')
         self.assertTrue('attachments' in actual_data)
-        
+
         # Verify the attachment structure
         attachment = actual_data['attachments'][0]
         self.assertEqual(attachment['color'], 'danger')
         self.assertEqual(attachment['title'], 'Error in /aws/lambda/test-function')
-        
+
         # Verify the fields
         fields = attachment['fields']
         self.assertEqual(len(fields), 3)
@@ -404,7 +404,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-        
+
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -438,7 +438,7 @@ class TestLambdaFunction(unittest.TestCase):
 
         # Check if SNS publish was called
         mock_sns_client.publish.assert_called_once()
-        
+
         # Verify the correct subject was used
         self.assertEqual(mock_sns_client.publish.call_args[1]['Subject'], 'CloudWatch Alert')
 
@@ -487,7 +487,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-        
+
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -531,29 +531,29 @@ class TestLambdaFunction(unittest.TestCase):
         self.assertEqual(actual_data['channel'], '#test-channel')
         self.assertEqual(actual_data['username'], 'CloudWatch-Bot')
         self.assertTrue('attachments' in actual_data)
-        
+
         # Verify the attachment structure
         attachment = actual_data['attachments'][0]
         self.assertEqual(attachment['color'], 'danger')
         self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
-        
+
         # Verify the fields
         fields = attachment['fields']
         self.assertEqual(len(fields), 4)
-        
+
         # Find fields by title
         state_field = next((f for f in fields if f['title'] == 'State'), None)
         self.assertIsNotNone(state_field)
         self.assertEqual(state_field['value'], 'ALARM')
-        
+
         region_field = next((f for f in fields if f['title'] == 'Region'), None)
         self.assertIsNotNone(region_field)
         self.assertEqual(region_field['value'], 'us-east-1')
-        
+
         desc_field = next((f for f in fields if f['title'] == 'Description'), None)
         self.assertIsNotNone(desc_field)
         self.assertEqual(desc_field['value'], 'This is a test alarm')
-        
+
         reason_field = next((f for f in fields if f['title'] == 'Reason'), None)
         self.assertIsNotNone(reason_field)
         self.assertEqual(reason_field['value'], 'Threshold Crossed')

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -279,7 +279,7 @@ class TestLambdaFunction(unittest.TestCase):
         request_args = mock_request.call_args[1]
         self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
         self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
-        
+
         # Parse the data to check fields
         data = json.loads(request_args['data'].decode('utf-8'))
         self.assertEqual(data['channel'], '#test-channel')
@@ -390,7 +390,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-        
+
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -424,14 +424,14 @@ class TestLambdaFunction(unittest.TestCase):
 
         # Check if SNS publish was called
         mock_sns_client.publish.assert_called_once()
-        
+
         # Verify the correct subject was used
         self.assertEqual(mock_sns_client.publish.call_args[1]['Subject'], 'CloudWatch Alert')
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
         self.assertEqual(json.loads(result['body']), 'Successfully processed CloudWatch Logs')
-        
+
     @patch('lambda_function.sns_client')
     @patch('lambda_function.urllib.request.Request')
     @patch('lambda_function.urllib.request.urlopen')
@@ -473,7 +473,7 @@ class TestLambdaFunction(unittest.TestCase):
                 "Threshold": 80.0
             }
         }
-        
+
         # Wrap it in an SNS event
         sns_message = json.dumps(cloudwatch_alarm)
         event = {
@@ -513,18 +513,18 @@ class TestLambdaFunction(unittest.TestCase):
         request_args = mock_request.call_args[1]
         self.assertEqual(request_args['headers'], {'Content-Type': 'application/json'})
         self.assertEqual(request_args['url'], os.environ['SLACK_WEBHOOK_URL'])
-        
+
         # Parse the data to check fields
         data = json.loads(request_args['data'].decode('utf-8'))
         self.assertEqual(data['channel'], '#test-channel')
         self.assertEqual(data['username'], 'CloudWatch-Bot')
         self.assertTrue('attachments' in data)
-        
+
         # Verify the alarm specific fields
         attachment = data['attachments'][0]
         self.assertEqual(attachment['color'], 'danger')  # ALARM state
         self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
-        
+
         # Find fields by title
         fields = attachment['fields']
         state_field = next((f for f in fields if f['title'] == 'State'), None)

--- a/functions/test_lambda_function.py
+++ b/functions/test_lambda_function.py
@@ -276,33 +276,23 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        call_args = mock_request.call_args
-        self.assertIsNotNone(call_args)
-        
-        # Get the positional arguments
-        args, kwargs = call_args
-        self.assertEqual(args[0], os.environ['SLACK_WEBHOOK_URL'])
-        
-        # Verify the request data
-        data = json.loads(args[1].decode('utf-8'))
-        self.assertEqual(data['channel'], '#test-channel')
-        self.assertEqual(data['username'], 'CloudWatch-Bot')
-        self.assertTrue('attachments' in data)
-        
-        # Verify the attachment structure
-        attachment = data['attachments'][0]
-        self.assertEqual(attachment['color'], 'danger')
-        self.assertEqual(attachment['title'], 'Error in /aws/lambda/test-function')
-        
-        # Verify the fields
-        fields = attachment['fields']
-        self.assertEqual(len(fields), 3)
-        self.assertEqual(fields[0]['title'], 'Log Group')
-        self.assertEqual(fields[0]['value'], '/aws/lambda/test-function')
-        self.assertEqual(fields[1]['title'], 'Log Stream')
-        self.assertEqual(fields[1]['value'], 'test-stream')
-        self.assertEqual(fields[2]['title'], 'Message')
-        self.assertEqual(fields[2]['value'], 'This is a test error message')
+        mock_request.assert_called_with(
+            os.environ['SLACK_WEBHOOK_URL'],
+            json.dumps({
+                'channel': '#test-channel',
+                'username': 'CloudWatch-Bot',
+                'attachments': [{
+                    'color': 'danger',
+                    'title': 'Error in /aws/lambda/test-function',
+                    'fields': [
+                        {'title': 'Log Group', 'value': '/aws/lambda/test-function', 'short': True},
+                        {'title': 'Log Stream', 'value': 'test-stream', 'short': True},
+                        {'title': 'Message', 'value': 'This is a test error message', 'short': False}
+                    ]
+                }]
+            }).encode('utf-8'),
+            {'Content-Type': 'application/json'}
+        )
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)
@@ -529,29 +519,24 @@ class TestLambdaFunction(unittest.TestCase):
         mock_urlopen.assert_called_once()
 
         # Verify that the Slack message contains the expected fields
-        call_args = mock_request.call_args
-        self.assertIsNotNone(call_args)
-        
-        # Get the positional arguments
-        args, kwargs = call_args
-        self.assertEqual(args[0], os.environ['SLACK_WEBHOOK_URL'])
-        
-        # Verify the request data
-        data = json.loads(args[1].decode('utf-8'))
-        self.assertEqual(data['channel'], '#test-channel')
-        self.assertEqual(data['username'], 'CloudWatch-Bot')
-        self.assertTrue('attachments' in data)
-        
-        # Verify the alarm specific fields
-        attachment = data['attachments'][0]
-        self.assertEqual(attachment['color'], 'danger')  # ALARM state
-        self.assertEqual(attachment['title'], 'CloudWatch Alarm: test-alarm')
-        
-        # Find fields by title
-        fields = attachment['fields']
-        state_field = next((f for f in fields if f['title'] == 'State'), None)
-        self.assertIsNotNone(state_field)
-        self.assertEqual(state_field['value'], 'ALARM')
+        mock_request.assert_called_with(
+            os.environ['SLACK_WEBHOOK_URL'],
+            json.dumps({
+                'channel': '#test-channel',
+                'username': 'CloudWatch-Bot',
+                'attachments': [{
+                    'color': 'danger',
+                    'title': 'CloudWatch Alarm: test-alarm',
+                    'fields': [
+                        {'title': 'State', 'value': 'ALARM', 'short': True},
+                        {'title': 'Region', 'value': 'us-east-1', 'short': True},
+                        {'title': 'Description', 'value': 'This is a test alarm', 'short': False},
+                        {'title': 'Reason', 'value': 'Threshold Crossed', 'short': False}
+                    ]
+                }]
+            }).encode('utf-8'),
+            {'Content-Type': 'application/json'}
+        )
 
         # Check the response
         self.assertEqual(result['statusCode'], 200)

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,12 @@ module "lambda_function" {
   package_type   = "Zip"
 
   environment_variables = {
-    SNS_ARN = module.sns.topic_arn
+    SNS_ARN           = module.sns.topic_arn
+    ENABLE_SLACK      = var.enable_slack_notifications ? "true" : "false"
+    SLACK_WEBHOOK_URL = var.slack_webhook_url
+    SLACK_CHANNEL     = var.slack_channel
+    SLACK_USERNAME    = var.slack_username
+    EMAIL_SUBJECT     = var.email_subject
   }
 
   cloudwatch_logs_retention_in_days = var.cloudwatch_log_group_retention_in_days
@@ -37,18 +42,26 @@ module "lambda_function" {
     var.additional_policy_statements
   )
 
-  allowed_triggers = {
-    CloudWatchLogs = {
-      principal  = "logs.${data.aws_region.current.name}.amazonaws.com"
-      source_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
-    }
-  }
+  allowed_triggers = merge(
+    {
+      CloudWatchLogs = {
+        principal  = "logs.${data.aws_region.current.name}.amazonaws.com"
+        source_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+      }
+    },
+    var.create_cloudwatch_alarm_sns_topic && var.enabled ? {
+      CloudWatchAlarmSNS = {
+        principal  = "sns.amazonaws.com"
+        source_arn = module.cloudwatch_alarm_sns.topic_arn
+      }
+    } : {}
+  )
 
   tags = var.tags
 }
 
 #######################
-# SNS Topic
+# SNS Topic for Notifications
 #######################
 
 module "sns" {
@@ -63,6 +76,29 @@ module "sns" {
     for idx, email in var.email_subscribers : "email-${idx}" => {
       protocol = "email"
       endpoint = email
+    }
+  }
+
+  tags = var.tags
+}
+
+#######################
+# SNS Topic for CloudWatch Alarms
+#######################
+
+module "cloudwatch_alarm_sns" {
+  source  = "terraform-aws-modules/sns/aws"
+  version = "6.1.3"
+
+  create       = var.create_cloudwatch_alarm_sns_topic && var.enabled
+  name         = var.cloudwatch_alarm_sns_topic_name
+  display_name = "CloudWatch Alarm Notifications"
+
+  # Subscribe the Lambda function to the SNS topic
+  subscriptions = {
+    lambda = {
+      protocol = "lambda"
+      endpoint = module.lambda_function.lambda_function_arn
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,16 @@ output "sns_topic_name" {
   value       = module.sns.topic_name
 }
 
+output "cloudwatch_alarm_sns_topic_arn" {
+  description = "The ARN of the SNS topic for CloudWatch alarm notifications"
+  value       = module.cloudwatch_alarm_sns.topic_arn
+}
+
+output "cloudwatch_alarm_sns_topic_name" {
+  description = "The name of the SNS topic for CloudWatch alarm notifications"
+  value       = module.cloudwatch_alarm_sns.topic_name
+}
+
 output "lambda_role_arn" {
   description = "The ARN of the IAM role used by the Lambda function"
   value       = module.lambda_function.lambda_role_arn
@@ -37,3 +47,4 @@ output "lambda_role_name" {
   description = "The name of the IAM role used by the Lambda function"
   value       = module.lambda_function.lambda_role_name
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,4 +47,3 @@ output "lambda_role_name" {
   description = "The name of the IAM role used by the Lambda function"
   value       = module.lambda_function.lambda_role_name
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,24 @@ variable "create_cloudwatch_log_subscription_filter" {
   default     = true
 }
 
+variable "create_cloudwatch_alarm_sns_topic" {
+  description = "Whether to create an SNS topic for CloudWatch alarms"
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_alarm_sns_topic_name" {
+  description = "The name of the SNS topic for CloudWatch alarm notifications"
+  type        = string
+  default     = "cloudwatch-alarm-notifications"
+}
+
+variable "email_subject" {
+  description = "The subject line to use for email notifications"
+  type        = string
+  default     = "CloudWatch Alert"
+}
+
 variable "function_name" {
   description = "The name of the Lambda function"
   type        = string
@@ -50,6 +68,31 @@ variable "email_subscribers" {
   description = "List of email addresses to subscribe to the SNS topic"
   type        = list(string)
   default     = []
+}
+
+variable "enable_slack_notifications" {
+  description = "Whether to enable Slack notifications"
+  type        = bool
+  default     = false
+}
+
+variable "slack_webhook_url" {
+  description = "The Slack webhook URL for notifications"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "slack_channel" {
+  description = "The Slack channel to send notifications to"
+  type        = string
+  default     = ""
+}
+
+variable "slack_username" {
+  description = "The username to display for Slack notifications"
+  type        = string
+  default     = "CloudWatch Logs"
 }
 
 variable "log_group_subscriptions" {


### PR DESCRIPTION
…#major

## Description
- Add CloudWatch Alarm SNS topic for unified notification pipeline
- Add email subject customization option
- Update Lambda function to handle CloudWatch Alarm notifications
- Add comprehensive documentation and examples
- Add test coverage for new functionality

This change allows users to:
1. Create a dedicated SNS topic for CloudWatch Alarms
2. Customize email notification subjects
3. Process both CloudWatch Logs and Alarm notifications through the same pipelineFixes # (issue)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How This Has Been Tested
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
